### PR TITLE
Add fragment mode to enchance

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const TEMPLATES = '@architect/views/templates'
 
 module.exports = function Enhancer(options={}) {
   const {
-    templates=TEMPLATES
+    templates = TEMPLATES,
+    fragmentExport = false
   } = options
 
   return function html(strings, ...values) {
@@ -15,8 +16,11 @@ module.exports = function Enhancer(options={}) {
     const moduleNames = [...new Set(customElements.map(node =>  node.tagName))]
     const templateTags = fragment(moduleNames.map(name => template(name, templates)).join(''))
     addTemplateTags(body, templateTags)
-    addScriptStripper(body)
-    return serialize(doc).replace(/__b_\d+/g, '')
+    if (!fragmentExport) {
+      addScriptStripper(body)
+      return serialize(doc).replace(/__b_\d+/g, '')
+    } 
+    else return serialize(doc.childNodes[0].childNodes[1]).replace(/__b_\d+/g, '')
   }
 }
 
@@ -209,6 +213,7 @@ function template(name, path) {
 function addTemplateTags(body, templates) {
   body.childNodes.unshift(...templates.childNodes)
 }
+
 
 function addScriptStripper(body) {
  const stripper = fragment(`<script>Array.from(document.getElementsByTagName("template")).forEach(t => 'SCRIPT' === t.content.lastElementChild.nodeName?document.body.appendChild(t.content.lastElementChild):'')</script>`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@architect/functions": "^4.0.0",
         "@begin/parse5": "^0.0.2",
-        "tap-spek": "^0.0.11"
+        "tap-arc": "^0.1.1"
       },
       "devDependencies": {
         "tape": "^5.2.2"
@@ -84,6 +84,14 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/asn1.js": {
@@ -2103,6 +2111,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/subarg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
@@ -2119,6 +2138,47 @@
         "acorn-node": "^1.2.0"
       }
     },
+    "node_modules/tap-arc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tap-arc/-/tap-arc-0.1.1.tgz",
+      "integrity": "sha512-Q9CaNfij91H9xICvGETmheZN8qtoEx4Zw6xCcprE0L6YtPU7+HmbSaCwTdN8sc6TXjW+9boKeUA/9zx4UCTX+Q==",
+      "dependencies": {
+        "fast-diff": "^1.2.0",
+        "json5": "^2.2.0",
+        "minimist": "~1.2.5",
+        "picocolors": "^1.0.0",
+        "strip-ansi": "^6.0.1",
+        "tap-parser": "^10.1.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "tap-arc": "index.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/tap-arc/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tap-arc/node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
     "node_modules/tap-parser": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
@@ -2133,42 +2193,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/tap-spek": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/tap-spek/-/tap-spek-0.0.11.tgz",
-      "integrity": "sha512-dWi0LIvS2tfhwsnGlUlmb3Sc8DFVH4MPx9GbO9MoCisF4tNR2EXqNn8tGp10Wmiq4DOoBgHJWljgIlDc4maI6w==",
-      "dependencies": {
-        "fast-diff": "^1.2.0",
-        "json5": "^2.2.0",
-        "picocolors": "^1.0.0",
-        "tap-parser": "^10.1.0",
-        "through2": "^4.0.2"
-      },
-      "bin": {
-        "tap-spek": "index.js"
-      }
-    },
-    "node_modules/tap-spek/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tap-spek/node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dependencies": {
-        "readable-stream": "3"
       }
     },
     "node_modules/tap-yaml": {
@@ -2516,6 +2540,11 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -4119,6 +4148,14 @@
         "define-properties": "^1.1.3"
       }
     },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "subarg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
@@ -4135,24 +4172,16 @@
         "acorn-node": "^1.2.0"
       }
     },
-    "tap-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
-      "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
-      "requires": {
-        "events-to-array": "^1.0.1",
-        "minipass": "^3.0.0",
-        "tap-yaml": "^1.0.0"
-      }
-    },
-    "tap-spek": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/tap-spek/-/tap-spek-0.0.11.tgz",
-      "integrity": "sha512-dWi0LIvS2tfhwsnGlUlmb3Sc8DFVH4MPx9GbO9MoCisF4tNR2EXqNn8tGp10Wmiq4DOoBgHJWljgIlDc4maI6w==",
+    "tap-arc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tap-arc/-/tap-arc-0.1.1.tgz",
+      "integrity": "sha512-Q9CaNfij91H9xICvGETmheZN8qtoEx4Zw6xCcprE0L6YtPU7+HmbSaCwTdN8sc6TXjW+9boKeUA/9zx4UCTX+Q==",
       "requires": {
         "fast-diff": "^1.2.0",
         "json5": "^2.2.0",
+        "minimist": "~1.2.5",
         "picocolors": "^1.0.0",
+        "strip-ansi": "^6.0.1",
         "tap-parser": "^10.1.0",
         "through2": "^4.0.2"
       },
@@ -4175,6 +4204,16 @@
             "readable-stream": "3"
           }
         }
+      }
+    },
+    "tap-parser": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
+      "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
+      "requires": {
+        "events-to-array": "^1.0.1",
+        "minipass": "^3.0.0",
+        "tap-yaml": "^1.0.0"
       }
     },
     "tap-yaml": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "description": "Server-side rendering for custom elements with template and slots support",
   "scripts": {
-    "test": "tape ./test/enhance.test.js | tap-spek"
+    "test": "tape ./test/enhance.test.js | tap-arc"
   },
   "keywords": [],
   "author": "kj <kj@begin.com>",
@@ -14,6 +14,6 @@
   "dependencies": {
     "@architect/functions": "^4.0.0",
     "@begin/parse5": "^0.0.2",
-    "tap-spek": "^0.0.11"
+    "tap-arc": "^0.1.1"
   }
 }

--- a/test/enhance.test.js
+++ b/test/enhance.test.js
@@ -61,6 +61,43 @@ test('expand template', t=> {
   t.end()
 })
 
+test('expand template in fragment mode', t=> {
+const htmlFragment = enhance({
+  templates: './test/fixtures/templates',
+  fragmentExport:true
+})
+  const actual = htmlFragment`<my-paragraph></my-paragraph>`
+  const expected = `
+<template id="my-paragraph-template">
+  <p>
+    <slot name="my-text">
+      My default text
+    </slot>
+  </p>
+  <script type="module">
+    class MyParagraph extends HTMLElement {
+      constructor() {
+        super()
+      }
+
+      connectedCallback() {
+        console.log('My Paragraph')
+      }
+    }
+  </script>
+</template>
+
+<my-paragraph>
+  <p><slot name="my-text">My default text</slot></p>
+</my-paragraph>
+`
+  t.equal(
+    strip(actual),
+    strip(expected),
+    'It expands a fragment just fine'
+  )
+  t.end()
+})
 test('fill named slot', t=> {
   const actual = html`
 <my-paragraph>


### PR DESCRIPTION
This is a first pass with adding fragment mode to enhance if you wanted to use it on a part of the page and not the whole page. I added a test. The only part this does not address is adding the hydrate script back in. I was going to export the hydrate script as below, but that would change how enhance is imported. How are you thinking you will export enhance helpers? As another npm package?

```javascript
const hydrateScript = `<script>Array.from(document.getElementsByTagName("template")).forEach(t => 'SCRIPT' === t.content.lastElementChild.nodeName?document.body.appendChild(t.content.lastElementChild):'')</script>`

module.exports = {html, hydrateScripts}
```